### PR TITLE
Feature/feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -719,6 +719,9 @@ FLAGS = {
 
     # Used to hide CCDB landing page updates prior to public launch.
     'CCDB_CONTENT_UPDATES': [],
+
+    # Toggle My Money Calendar tool pages prior to public launch.
+    'MMT_MY_MONEY_CALENDAR': [],
 }
 
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -138,9 +138,10 @@ urlpatterns = [
 
     # My Money Tools
     url(r'^mmt-my-money-calendar/$',
-        TemplateView.as_view(
-        template_name='mmt-my-money-calendar/index.html'),
-        name='mmt-my-money-calendar'),   
+        FlaggedTemplateView.as_view(
+            template_name='mmt-my-money-calendar/index.html',
+            flag_name='MMT_MY_MONEY_CALENDAR'),
+        name='mmt-my-money-calendar'),
 
     url(r'^practitioner-resources/students/knowbeforeyouowe/$',
         TemplateView.as_view(
@@ -318,7 +319,7 @@ urlpatterns = [
                 permanent=True)),
     url(r'^practitioner-resources/resources-youth-employment-programs/transportation-tool/$',  # noqa: E501
         TemplateView.as_view(
-            
+
             template_name='youth_employment_success/index.html'
         ),
         name='youth_employment_success'

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -137,7 +137,7 @@ urlpatterns = [
         name='fair-lending'),
 
     # My Money Tools
-    url(r'^mmt-my-money-calendar/$',
+    url(r'^mmt-my-money-calendar/.*',
         FlaggedTemplateView.as_view(
             template_name='mmt-my-money-calendar/index.html',
             flag_name='MMT_MY_MONEY_CALENDAR'),


### PR DESCRIPTION
Adds a feature flag to toggle availability of the My Money Calendar PWA in Django/Wagtail.

Flag can be toggled in Wagtail admin, Settings > Flags > `MMT_MY_MONEY_CALENDAR`.

I also edited the route leading to that app so that it serves the same view regardless of the trailing parts of the URL. This is needed to enable client-side routing in a single-page app, similar to adding a wildcard route to an Express app `app.get('*', () => {});`