### PR TITLE
Add money tools specific gulp task

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/components/counter.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/components/counter.js
@@ -6,17 +6,19 @@ function Counter({ initial = 0 }) {
   const increment = useCallback((evt) => {
     evt.preventDefault();
     setCount(count + 1);
-  }, []);
+  }, [count]);
   const decrement = useCallback((evt) => {
     evt.preventDefault();
     setCount(count - 1);
-  }, []);
+  }, [count]);
 
   return (
     <div className="counter">
       <h2>Counter</h2>
       <button onClick={decrement}>--</button>
+      <br />
       <strong>{count}</strong>
+      <br />
       <button onClick={increment}>++</button>
     </div>
   );

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -225,6 +225,56 @@ function scriptsApps() {
   return singleStream;
 }
 
+function scriptsMoneyTools(done) {
+  const apps = [
+    `${paths.unprocessed}/apps/mmt-my-money-calendar`,
+  ];
+  const streams = [];
+
+  const watch = process.argv.includes('--watch');
+
+  apps.forEach(appsPath => {
+    const app = path.basename(appsPath);
+    let appWebpackConfig = webpackConfig.appsConf;
+    const appWebpackConfigPath = path.join(appsPath, 'webpack-config.js');
+
+    if (fs.existsSync(appWebpackConfigPath)) {
+      appWebpackConfig = require(path.resolve(appWebpackConfigPath)).conf;
+    }
+
+    if (!fs.existsSync(path.join(appsPath, 'node_modules'))) {
+        // eslint-disable-next-line no-console
+        console.log(
+          '\x1b[31m%s\x1b[0m',
+          'App dependencies not installed, please run from project root:',
+          `yarn --cwd ${ appsPath }`
+        );
+        return done();
+    }
+
+    appWebpackConfig.watch = watch;
+
+    streams.push(
+      _processScript(
+        appWebpackConfig,
+        `/apps/${app}/js/index.js`,
+        `/apps/${app}/js`
+      )
+    );
+  });
+
+  let singleStream;
+
+  if (streams.length > 0) {
+    singleStream = mergeStream(...streams);
+  } else {
+    singleStream = mergeStream();
+  }
+
+  return singleStream;
+}
+
+gulp.task( 'scripts:moneytools', scriptsMoneyTools );
 gulp.task( 'scripts:apps', scriptsApps );
 gulp.task( 'scripts:external', scriptsExternal );
 gulp.task( 'scripts:modern', scriptsModern );


### PR DESCRIPTION
This adds a gulp task specifically for compiling the money tools apps we're working on. It can be run like this:

```sh
gulp scripts:moneytools
```

If you pass the `--watch` flag to the task, it will remain running and recompile whenever a file that is part of the Webpack bundle changes (e.g. anything that you `import` in the React app, whether it's a script, stylesheet, or whatever else):

```sh
gulp scripts:moneytools --watch
```

The only caveat here is that this runs _instead_ of frontend.sh, and we will need to manually run the other tasks that that script runs (since they're run much less frequently). If you change an image, for example, you'd need to run `gulp images` in a different terminal tab.