### PR TITLE
Add basic MobX structure

### DIFF
--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
@@ -1,15 +1,18 @@
+import * as idb from 'idb';
 import { render } from 'react-dom';
 import Greeting from './components/greeting';
 import Counter from './components/counter';
 import { configure as configureMobX } from 'mobx';
+import Routes from './routes';
 
 configureMobX({ enforceActions: 'observed' });
 
 const App = () => (
-  <div className="hello">
-    <Greeting />
-    <Counter />
-  </div>
+  <section className="my-money-calendar">
+    <Routes />
+  </section>
 );
+
+window.idb = idb;
 
 render(<App />, document.querySelector('#mmt-my-money-calendar'));

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/index.js
@@ -1,6 +1,9 @@
 import { render } from 'react-dom';
 import Greeting from './components/greeting';
 import Counter from './components/counter';
+import { configure as configureMobX } from 'mobx';
+
+configureMobX({ enforceActions: 'observed' });
 
 const App = () => (
   <div className="hello">

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/logger.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/lib/logger.js
@@ -1,0 +1,235 @@
+/* eslint-disable no-console */
+
+import { useEffect } from 'react';
+
+class Logger {
+  static wrappedMethods = [
+    'debug',
+    'log',
+    'info',
+    'warn',
+    'error',
+    'time',
+    'timeEnd',
+    'count',
+    'group',
+    'groupEnd',
+    'groupCollapsed',
+  ];
+
+  static storageKey = 'mmtLogger';
+
+  static defaults = {
+    active: [],
+  };
+
+  colors = [
+    ['#a6cee3', '#000'],
+    ['#1f78b4', '#fff'],
+    ['#b2df8a', '#000'],
+    ['#33a02c', '#fff'],
+    ['#fb9a99', '#fff'],
+    ['#e31a1c', '#fff'],
+    ['#fdbf6f', '#000'],
+    ['#ff7f00', '#fff'],
+    ['#cab2d6', '#fff'],
+    ['#6a3d9a', '#fff'],
+    ['#ffff99', '#000'],
+    ['#b15928', '#fff'],
+    ['#e41a1c', '#fff'],
+    ['#377eb8', '#fff'],
+    ['#4daf4a', '#fff'],
+    ['#984ea3', '#fff'],
+    ['#ff7f00', '#fff'],
+    ['#ffff33', '#000'],
+    ['#a65628', '#fff'],
+    ['#f781bf', '#fff'],
+    ['#999999', '#fff'],
+  ];
+
+  usedColors = [];
+
+  get storage() {
+    if (this._storage) return this._storage;
+
+    if (!('localStorage' in window)) return {};
+
+    try {
+      localStorage.setItem('logger.test', '1');
+      this._storage = localStorage;
+      return this._storage;
+    } catch (err) {
+      this._warn('localStorage not available for logger config');
+      this._storage = {};
+      return this._storage;
+    }
+  }
+
+  get config() {
+    if (this._config) return this._config;
+
+    this._config = this.loadConfig();
+    return this._config;
+  }
+
+  set config(obj) {
+    this.storage[this.constructor.storageKey] = JSON.stringify(obj);
+    this._config = obj;
+  }
+
+  get groupNames() {
+    return [...this.groups.keys()];
+  }
+
+  get activeGroups() {
+    return this.config.active;
+  }
+
+  constructor() {
+    const { storageKey, defaults } = this.constructor;
+    this._config = null;
+    //this.groups = {};
+    this.groups = new Map();
+
+    if (!this.storage[storageKey]) this.storage[storageKey] = JSON.stringify(defaults);
+  }
+
+  randomColor() {
+    return this.colors[Math.floor(Math.random() * this.colors.length)];
+  }
+
+  unusedColorPair() {
+    if (this.usedColors.length === this.colors.length) {
+      this.usedColors = [];
+    }
+
+    const index = Math.floor(Math.random() * this.colors.length);
+    const colorPair = this.colors[index];
+
+    if (!this.usedColors.includes(index)) {
+      this.usedColors.push(index);
+      return colorPair;
+    }
+
+    return this.unusedColorPair();
+  }
+
+  loadConfig() {
+    const config = this.storage[this.constructor.storageKey];
+    const parsed = config ? JSON.parse(config) : {};
+    return parsed;
+  }
+
+  updateConfig(params = {}) {
+    this.config = Object.assign({}, this.config, params);
+    this._info('Logger config updated: %O', this.config);
+  }
+
+  addGroup(name) {
+    if (this.groups.has(name)) return this.groups.get(name);
+
+    const [bgColor, fgColor] = this.unusedColorPair();
+    const labelStyle = `
+      background-color: ${bgColor};
+      color: ${fgColor};
+      font-weight: bold;
+      padding: 2px 4px;
+    `;
+    const resetStyle = `
+      background-color: inherit;
+      color: inherit;
+      font-weight: normal;
+      padding: 0;
+    `;
+
+    const group = this.constructor.wrappedMethods.reduce((obj, method) => {
+      obj[method] = (...args) => {
+        if (!this.config.active.includes(name)) return;
+
+        if (typeof args[0] === 'string') {
+          args[0] = `%c${name}%c ${args[0]}`;
+          args.splice(1, 0, labelStyle, resetStyle);
+        }
+
+        return console[method](...args);
+      };
+
+      return obj;
+    }, {});
+
+    group.color = bgColor;
+
+    this.groups.set(name, group);
+
+    return group;
+  }
+
+  enable(...groupNames) {
+    for (const groupName of groupNames) {
+      if (!this.groupNames.includes(groupName)) {
+        this._warn('Group named %s is not registered', groupName);
+        continue;
+      }
+
+      if (this.config.active.includes(groupName)) {
+        this._info('Group %s is already active', groupName);
+        continue;
+      }
+
+      const { active } = this.config;
+      active.push(groupName);
+      this.updateConfig({ active });
+      this._info('Enabled logging for group %s', groupName);
+    }
+  }
+
+  disable(...groupNames) {
+    for (const groupName of groupNames) {
+      let { active } = this.config;
+
+      if (!active.includes(groupName)) {
+        this._info('Group %s is already disabled', groupName);
+        continue;
+      }
+
+      this.updateConfig({
+        active: active.filter((name) => name !== groupName),
+      });
+      this._info('Disabled logging for group %s', groupName);
+    }
+  }
+
+  enableAll() {
+    this.updateConfig({
+      active: this.groupNames,
+    });
+    this._info('Enabled all groups (%O)', this.groupNames);
+  }
+
+  disableAll() {
+    this.updateConfig({ active: [] });
+    this._info('All groups disabled');
+  }
+
+  _warn(...args) {
+    console.warn(...args);
+  }
+
+  _info(...args) {
+    console.info(...args);
+  }
+}
+
+const logger = new Logger();
+
+window.logger = logger;
+
+export function useLogger(groupName, callback, deps = []) {
+  const group = logger.addGroup(groupName);
+
+  useEffect(() => {
+    callback(group);
+  }, deps);
+}
+
+export default logger;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/routes.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/routes.js
@@ -1,0 +1,21 @@
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import Home from './views/home';
+import Wizard from './views/wizard';
+
+const Routes = () => (
+  <Router basename="/mmt-my-money-calendar">
+    <div className="app">
+      <Switch>
+        <Route exact path="/">
+          <Home />
+        </Route>
+
+        <Route path="/wizard">
+          <Wizard />
+        </Route>
+      </Switch>
+    </div>
+  </Router>
+);
+
+export default Routes;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -8,6 +8,8 @@ export default class CashFlowStore {
   constructor(rootStore) {
     this.rootStore = rootStore;
     this.logger = logger.addGroup('cashFlowStore');
+
+    this.logger.debug('Initialize CashFlowStore: %O', this);
   }
 
   /**

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/cash-flow-store.js
@@ -1,0 +1,39 @@
+import { observable, computed, action } from 'mobx';
+import logger from '../lib/logger';
+import CashFlowEvent from './models/cash-flow-event';
+
+export default class CashFlowStore {
+  @observable eventsById = new Map();
+
+  constructor(rootStore) {
+    this.rootStore = rootStore;
+    this.logger = logger.addGroup('cashFlowStore');
+  }
+
+  /**
+   * Whenever eventsById is updates, this will regenerate the Map of events by date automatically
+   */
+  @computed get eventsByDate() {
+    const output = new Map();
+
+    for (const event of this.eventsById.values()) {
+      const events = output.get(event.date) || [];
+      events.push(event);
+      output.set(event.date, events);
+    }
+
+    return output;
+  }
+
+  @computed get allEvents() {
+    return [...this.eventsById.values()];
+  }
+
+  @action addEvent(event) {
+    this.eventsById.set(event.id, new CashFlowEvent(this, event));
+  }
+
+  @action deleteEvent(id) {
+    this.eventsById.delete(id);
+  }
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/index.js
@@ -1,0 +1,15 @@
+import React, { createContext, useContext } from 'react';
+import RootStore from './root-store';
+
+const store = new RootStore();
+const StoreContext = createContext(null);
+
+export const StoreProvider = ({ children }) => (
+  <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
+);
+
+export const StoreConsumer = StoreContext.Consumer;
+
+export const useStore = () => useContext(StoreContext);
+
+export default StoreContext;

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/cash-flow-event.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/models/cash-flow-event.js
@@ -1,0 +1,15 @@
+import { observable, computed, action, extendObservable } from 'mobx';
+import logger from '../../lib/logger';
+
+export default class CashFlowEvent {
+  static isCashFlowEvent(obj) {
+    return obj instanceof CashFlowEvent;
+  }
+
+  constructor(store, props) {
+    this.store = store;
+    this.logger = logger.addGroup('cashFlowEvent');
+
+    extendObservable(this, props);
+  }
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/root-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/root-store.js
@@ -10,6 +10,8 @@ export default class RootStore {
     this.logger = logger.addGroup('rootStore');
     this.uiStore = new UIStore(this);
     this.eventStore = new CashFlowStore(this);
+
+    this.logger.debug('Initialize RootStore: %O', this);
   }
 
   @computed get isLoading() {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/root-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/root-store.js
@@ -1,13 +1,15 @@
 import { observable, action, computed } from 'mobx';
 import logger from '../lib/logger';
+import UIStore from './ui-store';
+import CashFlowStore from './cash-flow-store';
 
 export default class RootStore {
   @observable networkStatus = 'idle';
 
   constructor() {
-    this.logger = logger.addGroup('RootStore');
-
-    // TODO: Add child data store instances here
+    this.logger = logger.addGroup('rootStore');
+    this.uiStore = new UIStore(this);
+    this.eventStore = new CashFlowStore(this);
   }
 
   @computed get isLoading() {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/root-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/root-store.js
@@ -1,0 +1,24 @@
+import { observable, action, computed } from 'mobx';
+import logger from '../lib/logger';
+
+export default class RootStore {
+  @observable networkStatus = 'idle';
+
+  constructor() {
+    this.logger = logger.addGroup('RootStore');
+
+    // TODO: Add child data store instances here
+  }
+
+  @computed get isLoading() {
+    return this.networkStatus === 'loading';
+  }
+
+  @computed get hasNetworkError() {
+    return this.networkStatus === 'error';
+  }
+
+  @action setNetworkStatus(val) {
+    this.networkStatus = val;
+  }
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -7,6 +7,8 @@ export default class UIStore {
   constructor(rootStore) {
     this.rootStore = rootStore;
     this.logger = logger.addGroup('uiStore');
+
+    this.logger.debug('Initialize UI Store: %O', this);
   }
 
   @action setNavOpen(val) {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/stores/ui-store.js
@@ -1,0 +1,19 @@
+import { observable, computed, action } from 'mobx';
+import logger from '../lib/logger';
+
+export default class UIStore {
+  @observable navOpen = false;
+
+  constructor(rootStore) {
+    this.rootStore = rootStore;
+    this.logger = logger.addGroup('uiStore');
+  }
+
+  @action setNavOpen(val) {
+    this.navOpen = Boolean(val);
+  }
+
+  toggleNav() {
+    this.setNavOpen(!this.navOpen);
+  }
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/home/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/home/index.js
@@ -1,0 +1,10 @@
+import { Link } from 'react-router-dom';
+
+export default function Home() {
+  return (
+    <main className="mmt-view home">
+      <h1>Home</h1>
+      <Link to="/wizard">Begin Wizard</Link>
+    </main>
+  );
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/wizard/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/wizard/index.js
@@ -1,4 +1,4 @@
-import { Route, Redirect, Switch, useRouteMatch } from 'react-router-dom';
+import { Route, Redirect, Switch, Link, useRouteMatch } from 'react-router-dom';
 import Step from './step';
 
 export default function Wizard() {
@@ -7,6 +7,13 @@ export default function Wizard() {
   return (
     <section className="wizard">
       <h1>New User Wizard</h1>
+
+      <Link to="/">Back Home</Link>
+
+      <h3>Route match debug</h3>
+      <pre className="debug">
+        {JSON.stringify(match, null, 2)}
+      </pre>
 
       <Switch>
         <Redirect exact from="/wizard" to="/wizard/step/1" />

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/wizard/index.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/wizard/index.js
@@ -1,0 +1,19 @@
+import { Route, Redirect, Switch, useRouteMatch } from 'react-router-dom';
+import Step from './step';
+
+export default function Wizard() {
+  const match = useRouteMatch('/wizard/step/:step');
+
+  return (
+    <section className="wizard">
+      <h1>New User Wizard</h1>
+
+      <Switch>
+        <Redirect exact from="/wizard" to="/wizard/step/1" />
+        <Route path="/step/:step">
+          <Step />
+        </Route>
+      </Switch>
+    </section>
+  );
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/wizard/step.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/js/views/wizard/step.js
@@ -1,0 +1,11 @@
+import { Link, useRouteMatch } from 'react-router-dom';
+
+export default function Step() {
+  const match = useRouteMatch('/step/:step');
+
+  return (
+    <div className="wizard-step">
+      <h2>Step {match.params.step}</h2>
+    </div>
+  );
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/jsconfig.json
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
@@ -14,6 +14,7 @@
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
+    "react-router-dom": "5.1.2",
     "react-use": "13.14.3"
   },
   "devDependencies": {

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
@@ -6,7 +6,10 @@
   "homepage": "https://www.consumerfinance.gov/mmt-my-money-calendar",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "7.7.4",
+    "@babel/plugin-proposal-decorators": "7.8.3",
     "@babel/preset-react": "7.7.4",
+    "mobx": "5.15.2",
+    "mobx-react": "6.1.5",
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/package.json
@@ -8,6 +8,7 @@
     "@babel/plugin-proposal-class-properties": "7.7.4",
     "@babel/plugin-proposal-decorators": "7.8.3",
     "@babel/preset-react": "7.7.4",
+    "idb": "5.0.0",
     "mobx": "5.15.2",
     "mobx-react": "6.1.5",
     "prop-types": "15.7.2",

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/webpack-config.js
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/webpack-config.js
@@ -3,9 +3,6 @@ const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
-const reactPreset = require('@babel/preset-react');
-const classPropertiesPlugin = require('@babel/plugin-proposal-class-properties');
-
 // Used for toggling debug output. Inherit Django debug value to cut down on redundant environment variables:
 const {
   DJANGO_DEBUG: DEBUG = false,
@@ -53,14 +50,13 @@ const COMMON_MODULE_CONFIG = {
               debug: DEBUG,
               targets: LAST_2_IE_11_UP,
             }],
-            [reactPreset, {
+            [require('@babel/preset-react'), {
               development: NODE_ENV === 'development',
             }],
           ],
           plugins: [
-            [classPropertiesPlugin, {
-              loose: true,
-            }],
+            [require('@babel/plugin-proposal-decorators'), { legacy: true }],
+            [require('@babel/plugin-proposal-class-properties'), { loose: true }],
           ],
         },
       },

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
@@ -9,12 +9,29 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
 "@babel/generator@^7.7.4":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.7.tgz#859ac733c44c74148e1a72980a64ec84b85f4f45"
   integrity sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==
   dependencies:
     "@babel/types" "^7.7.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
+  integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+  dependencies:
+    "@babel/types" "^7.8.3"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -39,6 +56,18 @@
     "@babel/helper-replace-supers" "^7.7.4"
     "@babel/helper-split-export-declaration" "^7.7.4"
 
+"@babel/helper-create-class-features-plugin@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz#5b94be88c255f140fd2c10dd151e7f98f4bff397"
+  integrity sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==
+  dependencies:
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+
 "@babel/helper-function-name@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e"
@@ -48,12 +77,28 @@
     "@babel/template" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/helper-function-name@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
+  integrity sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-get-function-arity@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
   integrity sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-member-expression-to-functions@^7.7.4":
   version "7.7.4"
@@ -62,6 +107,13 @@
   dependencies:
     "@babel/types" "^7.7.4"
 
+"@babel/helper-member-expression-to-functions@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
+  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-optimise-call-expression@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz#034af31370d2995242aa4df402c3b7794b2dcdf2"
@@ -69,10 +121,22 @@
   dependencies:
     "@babel/types" "^7.7.4"
 
+"@babel/helper-optimise-call-expression@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
+  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-plugin-utils@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
+
+"@babel/helper-plugin-utils@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
+  integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
 
 "@babel/helper-replace-supers@^7.7.4":
   version "7.7.4"
@@ -84,12 +148,29 @@
     "@babel/traverse" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/helper-replace-supers@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz#91192d25f6abbcd41da8a989d4492574fb1530bc"
+  integrity sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/traverse" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-split-export-declaration@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8"
   integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/highlight@^7.0.0":
   version "7.5.0"
@@ -100,10 +181,24 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
+  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.7.4":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.7.tgz#1b886595419cf92d811316d5b715a53ff38b4937"
   integrity sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==
+
+"@babel/parser@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
+  integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
 
 "@babel/plugin-proposal-class-properties@7.7.4":
   version "7.7.4"
@@ -112,6 +207,22 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-proposal-decorators@7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz#2156860ab65c5abf068c3f67042184041066543e"
+  integrity sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-decorators" "^7.8.3"
+
+"@babel/plugin-syntax-decorators@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz#8d2c15a9f1af624b0025f961682a9d53d3001bda"
+  integrity sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-syntax-jsx@^7.7.4":
   version "7.7.4"
@@ -179,6 +290,15 @@
     "@babel/parser" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/template@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
+  integrity sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/traverse@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558"
@@ -194,10 +314,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.3.tgz#a826215b011c9b4f73f3a893afbc05151358bf9a"
+  integrity sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.3"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
   integrity sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
+  integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -665,6 +809,23 @@ mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mobx-react-lite@^1.4.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz#c4395b0568b9cb16f07669d8869cc4efa1b8656d"
+  integrity sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==
+
+mobx-react@6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.1.5.tgz#66a6f67bfe845216abc05d3aea47ceec8e31e2dd"
+  integrity sha512-EfWoXmGE2CfozH4Xirb65+il1ynHFCmxBSUabMSf+511YfjVs6QRcCrHkiVw+Il8iWp1gIyfa9qKkUgbDA9/2w==
+  dependencies:
+    mobx-react-lite "^1.4.2"
+
+mobx@5.15.2:
+  version "5.15.2"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.2.tgz#010a6abf49add64a3372966d17a01416e7e40655"
+  integrity sha512-eVmHGuSYd0ZU6x8gYMdgLEnCC9kfBJaf7/qJt+/yIxczVVUiVzHvTBjZH3xEa5FD5VJJSh1/Ba4SThE4ErEGjw==
 
 ms@2.0.0:
   version "2.0.0"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
@@ -281,6 +281,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.4.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -687,6 +694,11 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 gzip-size@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -699,6 +711,25 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
+hoist-non-react-statics@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
+  integrity sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==
+  dependencies:
+    react-is "^16.7.0"
 
 hoopy@^0.1.4:
   version "0.1.4"
@@ -776,6 +807,11 @@ is-reference@^1.1.2:
   dependencies:
     "@types/estree" "0.0.39"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
@@ -796,7 +832,7 @@ lodash@^4.17.13, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -846,6 +882,15 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mini-create-react-context@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz#79fc598f283dd623da8e088b05db8cddab250189"
+  integrity sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  dependencies:
+    "@babel/runtime" "^7.4.0"
+    gud "^1.0.0"
+    tiny-warning "^1.0.2"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -942,6 +987,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
@@ -999,10 +1051,39 @@ react-fast-compare@^2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-is@^16.8.1:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-router-dom@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
+  integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.1.2"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"
+  integrity sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.3.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-use@13.14.3:
   version "13.14.3"
@@ -1039,6 +1120,11 @@ resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve@^1.11.0:
   version "1.14.2"
@@ -1187,6 +1273,16 @@ throttle-debounce@^2.1.0:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
   integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
+tiny-invariant@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -1234,6 +1330,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"

--- a/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
+++ b/cfgov/unprocessed/apps/mmt-my-money-calendar/yarn.lock
@@ -347,6 +347,29 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@rollup/plugin-commonjs@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.1.tgz#6056a6757286901cc6c1599123e6680a78cad6c2"
+  integrity sha512-SaVUoaLDg3KnIXC5IBNIspr1APTYDzk05VaYcI6qz+0XX3ZlSCwAkfAhNSOxfd5GAdcm/63Noi4TowOY9MpcDg==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.0"
+    estree-walker "^0.6.1"
+    is-reference "^1.1.2"
+    magic-string "^0.25.2"
+    resolve "^1.11.0"
+
+"@rollup/pluginutils@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.0.4.tgz#3a104a41a90f8d1dcf308e18f8fa402d1cc6576e"
+  integrity sha512-buc0oeq2zqQu2mpMyvZgAaQvitikYjT/4JYhA4EXwxX8/g0ZGHoGiX+0AwmfhrNqH4oJv67gn80sTZFQ/jL1bw==
+  dependencies:
+    estree-walker "^0.6.1"
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@xobotyi/scrollbar-width@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.5.0.tgz#488210bff634548040dc22a72f62722a85b134e1"
@@ -570,6 +593,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -711,6 +739,13 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+idb@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-5.0.0.tgz#b93d1e499d932959358a49fb6dd1c23c1157ef55"
+  integrity sha512-TmUY6ogQgb9xbsIZzJx/rV6r9gAP0qIEmrGQz1ZpBOkgoG7a7E+H35P1wAn6DXI9rG3guBbt80sGHEv/LBUzGw==
+  dependencies:
+    "@rollup/plugin-commonjs" "^11.0.1"
+
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
@@ -733,6 +768,13 @@ ipaddr.js@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
   integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
+
+is-reference@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.4.tgz#3f95849886ddb70256a3e6d062b1a68c13c51427"
+  integrity sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==
+  dependencies:
+    "@types/estree" "0.0.39"
 
 isobject@^3.0.1:
   version "3.0.1"
@@ -760,6 +802,13 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+magic-string@^0.25.2:
+  version "0.25.6"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.6.tgz#5586387d1242f919c6d223579cc938bf1420795e"
+  integrity sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 mdn-data@2.0.6:
   version "2.0.6"
@@ -883,6 +932,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -986,6 +1040,13 @@ resize-observer-polyfill@^1.5.1:
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
+resolve@^1.11.0:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
+  integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+  dependencies:
+    path-parse "^1.0.6"
+
 rtl-css-js@^1.9.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.0.tgz#daa4f192a92509e292a0519f4b255e6e3c076b7d"
@@ -1070,7 +1131,7 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcemap-codec@^1.4.1:
+sourcemap-codec@^1.4.1, sourcemap-codec@^1.4.4:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.7.tgz#5b2cd184e3fe51fd30ba049f7f62bf499b4f73ae"
   integrity sha512-RuN23NzhAOuUtaivhcrjXx1OPXsFeH9m5sI373/U7+tGLKihjUyboZAzOadytMjnqHp1f45RGk1IzDKCpDpSYA==


### PR DESCRIPTION
This adds MobX initialization code, some skeletal data store modules for the UI, cash flow events (income and expenses on the calendar), and routes to navigate between views on the client side. 

The server already has rules in place to allow client-side routing, so once this merges we'll be able to use `Link` components and enable browser history navigation and bookmarking client-side URLs.

None of the components actually interact with any of the MobX data stores yet.

The last thing I added in this PR is a `Logger` module that I'll show you how to use. It allows us to add debug logging statements that are all hidden from users by default, but provides an API we can use in devtools console to make the log messages from specific components visible to us.